### PR TITLE
[QA] #134 이메일 인증 메일 재전송 api 생성

### DIFF
--- a/src/components/sign/EmailAuth.js
+++ b/src/components/sign/EmailAuth.js
@@ -7,20 +7,28 @@ import StyledInput from '../../styles/StyledInput';
 import LinkModal from '../common/Modal/LinkModal';
 import ConfirmModal from '../common/Modal/ConfirmModal';
 
-function EmailAuth({ authNum, onChange, onSubmit, linkModalOn, handleLinkModal, errModalOn, handleErrModal, errMsg }) {
+function EmailAuth({ authNum, onChange, onSubmit, onResend,linkModalOn, handleLinkModal,resendModalOn, handleResendModal, errModalOn, handleErrModal, errMsg }) {
   return (
     <>
-      <StyledP>입력하신 이메일 계정으로 인증 메일을 발송하였습니다.</StyledP>
+      <StyledP>입력하신 이메일 계정으로 인증 메일을 전송하였습니다.</StyledP>
       <StyledP>인증을 통해 가입을 완료해 주세요.</StyledP>
       <StyledInput type="text" name="authNum" value={authNum} placeholder="인증번호" onChange={onChange} />
       <StyledButton onClick={onSubmit}>이메일 인증하기</StyledButton>
       <StyledP className="info">혹시 메일을 받지 못하셨다면 스팸 메일함을 확인해주세요.</StyledP>
+      <ResendButton type="button" onClick={onResend}>인증 메일 다시 받기</ResendButton>
       {linkModalOn && (
         <LinkModal
           onClose={handleLinkModal}
           title="회원가입 성공"
           content="가입한 계정으로 로그인하세요."
           link="/login"
+        />
+      )}
+      {resendModalOn && (
+        <ConfirmModal
+          onClose={handleResendModal}
+          title="인증 메일 재발송"
+          content="인증 메일을 재발송하였습니다."
         />
       )}
       {errModalOn && <ConfirmModal onClose={handleErrModal} title="이메일 인증 실패!" content={errMsg} />}
@@ -32,8 +40,11 @@ EmailAuth.propTypes = {
   authNum: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
+  onResend: PropTypes.func.isRequired,
   linkModalOn: PropTypes.bool.isRequired,
   handleLinkModal: PropTypes.func.isRequired,
+  resendModalOn: PropTypes.bool.isRequired,
+  handleResendModal: PropTypes.func.isRequired,
   errModalOn: PropTypes.bool.isRequired,
   handleErrModal: PropTypes.func.isRequired,
   errMsg: PropTypes.string.isRequired,
@@ -50,7 +61,12 @@ const StyledP = styled.p`
   }
 
   &.info {
-    margin: 30px 0;
+    margin: 30px 0 10px 0;
     color: #888383;
   }
+`;
+
+const ResendButton = styled.button`
+  color: #888383;
+  border-bottom: 1px solid #888383;
 `;

--- a/src/pages/sign/EmailAuthPage.js
+++ b/src/pages/sign/EmailAuthPage.js
@@ -13,6 +13,11 @@ function EmailAuthPage() {
     setLinkModalOn(!linkModalOn);
   };
 
+  const [resendModalOn, setResendModalOn] = useState(false);
+  const handleResendModal = () => {
+    setResendModalOn(!resendModalOn);
+  };
+
   const [errModalOn, setErrModalOn] = useState(false);
   const [errMsg, setErrMsg] = useState('');
 
@@ -43,14 +48,35 @@ function EmailAuthPage() {
     }
   };
 
+  const onResend = async e => {
+    e.preventDefault();
+
+    try {
+      const { data } = await axios.post('users/email-auth/join', {
+        idx: userIdx,
+      });
+
+      if (data.success) {
+        setResendModalOn(() => true);
+      }
+    } catch (err) {
+      setErrModalOn(prev => !prev);
+      setErrMsg(err.response.data.error);
+      setAuthNum('');
+    }
+  };
+
   return (
     <TitleWrapper title="이메일 인증">
       <EmailAuth
         onChange={onChange}
         onSubmit={onSubmit}
+        onResend={onResend}
         authNum={authNum}
         linkModalOn={linkModalOn}
         handleLinkModal={handleLinkModal}
+        resendModalOn={resendModalOn}
+        handleResendModal={handleResendModal}
         errModalOn={errModalOn}
         handleErrModal={handleErrModal}
         errMsg={errMsg}


### PR DESCRIPTION
## Motivation 🤓
회원가입 후, 이메일 인증을 하지 않은 유저가 로그인시, 이전 메일을 찾기 어려울 때를 위해 `이메일 재전송 기능`을 추가하고자 함.
<br>

## Key Changes 🔑
![스크린샷 2022-04-27 오후 9 06 02](https://user-images.githubusercontent.com/57309520/165514501-4d521feb-fed0-4886-8db7-5982d3f189ad.png)

재전송 횟수를 제한하면 좋겠지만.... 현재로서 시간이 부족함.😭

<br>

## To Reviewers 🙋‍♀️

close #134
