### PR TITLE
[Feat] #154 마이페이지 프로필 순서 변경/세션 만료 오류메세지 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movester_client_product",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "dependencies": {
     "@material-ui/icons": "^4.11.2",

--- a/src/components/common/Error.js
+++ b/src/components/common/Error.js
@@ -5,7 +5,7 @@ function Error() {
   return (
     <StyledError className="error">
       <img src="/assets/sorry.png" alt="잠시후 다시 시도해 주세요" />
-      <p>죄송합니다 잠시 후 다시 시도해 주세요...</p>
+      <p>세션이 만료되었습니다. 다시 로그인해주세요!</p>
     </StyledError>
   );
 }

--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -37,14 +37,14 @@ function Header() {
             <Link to="/about">서비스</Link>
             <Link to="/stretching">스트레칭</Link>
             <Link to="/event">이벤트</Link>
-            {isAuth ? <Link to="/mypage/profile">마이페이지</Link> : ''}
+            {isAuth ? <Link to="/mypage/stamp">마이페이지</Link> : ''}
           </StyledNavigation>
         </div>
       </HeaderLeftBlock>
       <HeaderRightBlock>
         {isAuth ? (
           <>
-            <Link to="/mypage/profile">
+            <Link to="/mypage/stamp">
               <NavProfileButton handleClick={handleInfo} user={user} />
             </Link>
             {isInfo}

--- a/src/components/common/Nav.js
+++ b/src/components/common/Nav.js
@@ -15,23 +15,23 @@ function Nav() {
   const mypageList = [
     {
       id: 0,
-      title: '프로필',
-      path: '/mypage/profile',
-    },
-    {
-      id: 1,
-      title: '찜한 스트레칭',
-      path: '/mypage/like',
-    },
-    {
-      id: 2,
       title: '출석도장',
       path: '/mypage/stamp',
     },
     {
-      id: 3,
+      id: 1,
       title: '기록',
       path: '/mypage/record',
+    },
+    {
+      id: 2,
+      title: '찜한 스트레칭',
+      path: '/mypage/like',
+    },
+    {
+      id: 3,
+      title: '프로필',
+      path: '/mypage/profile',
     },
   ];
 

--- a/src/components/elements/NavigationDropMenu.js
+++ b/src/components/elements/NavigationDropMenu.js
@@ -28,9 +28,16 @@ function NavigationDropMenu({ isAuth, handleMenu }) {
         </button>
       </NavLink>
       {isAuth && (
-        <NavLink to="/mypage/profile">
+        <NavLink to="/mypage/stamp">
           <button type="button" onClick={handleMenu}>
-            프로필
+            출석도장
+          </button>
+        </NavLink>
+      )}
+      {isAuth && (
+        <NavLink to="/mypage/record">
+          <button type="button" onClick={handleMenu}>
+            기록
           </button>
         </NavLink>
       )}
@@ -42,16 +49,9 @@ function NavigationDropMenu({ isAuth, handleMenu }) {
         </NavLink>
       )}
       {isAuth && (
-        <NavLink to="/mypage/stamp">
+        <NavLink to="/mypage/profile">
           <button type="button" onClick={handleMenu}>
-            출석도장
-          </button>
-        </NavLink>
-      )}
-      {isAuth && (
-        <NavLink to="/mypage/record">
-          <button type="button" onClick={handleMenu}>
-            기록
+            프로필
           </button>
         </NavLink>
       )}

--- a/src/components/elements/ProfileDropMenu.js
+++ b/src/components/elements/ProfileDropMenu.js
@@ -13,10 +13,10 @@ function ProfileDropMenu({ user }) {
         <span className="user-email">{user.email}</span>
       </UserInfoContainer>
       <StyledNavigation>
-        <NavLink to="/mypage/profile">프로필</NavLink>
-        <NavLink to="/mypage/basket">찜한 스트레칭</NavLink>
         <NavLink to="/mypage/stamp">출석도장</NavLink>
         <NavLink to="/mypage/Record">기록</NavLink>
+        <NavLink to="/mypage/basket">찜한 스트레칭</NavLink>
+        <NavLink to="/mypage/profile">프로필</NavLink>
       </StyledNavigation>
     </ProfileDropMenuWrapper>
   );


### PR DESCRIPTION
## Motivation 🤓
마이페이지 이동시, 첫 랜딩 페이지에 회원 탈퇴가 노출됨.
UX 적으로 좋지 않다고 판단.
첫 랜딩페이지 변경
<br>

## Key Changes 🔑
프로필 리스트 순서 변경
<br>

## To Reviewers 🙋‍♀️
.

## AS-IS
<img width="535" alt="image" src="https://user-images.githubusercontent.com/57309520/184530728-cb29b097-bb1c-4adf-ae52-a8d65fe9e8c8.png">

## TO-BE
<img width="174" alt="image" src="https://user-images.githubusercontent.com/57309520/184531134-01119ac1-4b81-474a-ba36-7030b12994e5.png">

close #154 
